### PR TITLE
Convert movie path if not URL encoded

### DIFF
--- a/MovieNightRedirect/MovieNightRedirect.cs
+++ b/MovieNightRedirect/MovieNightRedirect.cs
@@ -247,6 +247,11 @@ namespace MovieNightRedirect
                     MovieNightRedirect.Toggle3DMode(false);
                 }
 
+                if (File.Exists(Uri.UnescapeDataString(path)))
+                {
+                    path = Uri.UnescapeDataString(path);
+                }
+
                 if (File.Exists(path))
                 {
                     MovieNightRedirect.Log.Msg($"Found local movie night file for {path}! Replacing online link!");


### PR DESCRIPTION
Currently, MovieNightRedirect expects the local file to be named the same way as the URL. When I download the file, the filename gets automatically converted and is a pain to unconvert it. For example, all spaces in a URL is "%20" but its " " in local file